### PR TITLE
Fix dashboard search returned scopes

### DIFF
--- a/src/client/client.controller.ts
+++ b/src/client/client.controller.ts
@@ -138,8 +138,8 @@ export class ClientController {
             skip = 0;
         }
 
-        // If the usage sort option is passed, need to pass the teams of the user to the search
-        if (req.person && sort === ClientRepository.SortOptions.USAGE) {
+        // Need to pass the teams of the user to filter only the permitted clients of the user teams.
+        if (req.person) {
             teams = (await TeamRepository.findByUserId(req.person.genesisId)).map(team => team._id);
         }
 

--- a/src/person/person.controller.ts
+++ b/src/person/person.controller.ts
@@ -8,6 +8,22 @@ import { LOG_LEVEL, log, parseLogData } from '../utils/logger';
 import { NotFound, InvalidParameter } from '../utils/error';
 
 export class PersonController {
+
+    /**
+     * Gets person by id from kartoffel API
+     * @param req - Request
+     * @param res - Response
+     */
+    public static async getPersonById(req: Request, res: Response) {
+        const person = 
+            await axios.default.get(
+                `${process.env.KARTOFFEL_URL}/api/persons/${req.params.id}`,
+                { headers: { authorization: await getToken() } },
+            );
+
+        res.send(person);
+    }
+
     /**
      * Gets persons from kartoffel API
      * @param req - Request

--- a/src/person/person.router.ts
+++ b/src/person/person.router.ts
@@ -8,6 +8,7 @@ export class PersonRouter {
 
     get router() {
         const router: Router = Router();
+        router.get('/:id', Wrapper.wrapAsync(PersonController.getPersonById));
         router.get('/', Wrapper.wrapAsync(PersonController.getPersonsByName));
         router.post('/', Wrapper.wrapAsync(PersonController.getPersonsByList));
         return router;


### PR DESCRIPTION
## Status
**READY**

## Description
* Set in every scope the permitted clients in dashboard search to be only the clients which the user has on his team.
* Add option to get person by id from Kartoffel API.
